### PR TITLE
in linkcheck, theme_options attribute may not be defined

### DIFF
--- a/src/jupyterhub_sphinx_theme/__init__.py
+++ b/src/jupyterhub_sphinx_theme/__init__.py
@@ -19,7 +19,10 @@ def _config_provided_by_user(app, key):
 
 def set_config_defaults(app):
     config = app.config
-    theme = app.builder.theme_options
+    try:
+        theme = app.builder.theme_options
+    except AttributeError:
+        theme = None
     if not theme:
         theme = {}
 


### PR DESCRIPTION
Revealed in https://github.com/jupyterhub/jupyterhub/pull/4363

Strangely, I can't seem to reproduce this locally, but I haven't worked too hard at it.