### PR TITLE
Mention updating version in release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Follow these steps:
    # in requirements.txt
    git+https://github.com/jupyterhub/jupyterhub-sphinx-theme
    ```
-  
+
    or to install locally
-  
+
    ```console
    $ pip install git+https://github.com/jupyterhub/jupyterhub-sphinx-theme
    ```
@@ -51,14 +51,14 @@ Follow these steps:
 
    ```{code-block} python
    :caption: conf.py
-   
+
    html_theme = "jupyterhub_sphinx_theme"
    ```
 3. Add it to your theme's extensions:
 
    ```{code-block} python
    :caption: conf.py
-   
+
    extensions = [
       "jupyterhub_sphinx_theme"
    ]
@@ -111,5 +111,10 @@ $ nox -s docs-live
 
 ## Make a release
 
-To make a release, [make a release on GitHub](https://github.com/jupyterhub/jupyterhub-sphinx-theme/releases).
+To make a release:
+
+- update the version number in `src/jupyterhub_sphinx_theme/__init__.py`
+- push the changes
+- [make a release on GitHub](https://github.com/jupyterhub/jupyterhub-sphinx-theme/releases).
+
 When you finish this process, a GitHub Action will trigger to package and upload the release to PyPI.

--- a/src/jupyterhub_sphinx_theme/__init__.py
+++ b/src/jupyterhub_sphinx_theme/__init__.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from sphinx.util import logging
 
-__version__ = "0.0.1"
+__version__ = "0.0.3"
 
 THEME_PATH = (Path(__file__).parent / "theme" / "jupyterhub-sphinx-theme").resolve()
 


### PR DESCRIPTION
I tried to follow the release steps in the README to publish 0.0.2 so we could get the jupyterhub docs passing with #6 , but it didn't mention that the version number needed to be updated (I assumed from the described steps that it was versioneer-style version-from-git, but I was wrong). This also bumps to 0.0.3 so that we can make an 0.0.3 after merge.