### PR TITLE
Fix html_logo not being respected

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ requires = ["sphinx-theme-builder"]
 build-backend = "sphinx_theme_builder"
 
 [tool.sphinx-theme-builder]
-node-version = "16.13.0"
+# ref, pydata-sphinx-theme's node version: https://github.com/pydata/pydata-sphinx-theme/blob/main/pyproject.toml
+# ref, latest node LTS version: https://nodejs.org/en
+node-version = "16.3.2"
 
 [project]
 name = "jupyterhub-sphinx-theme"
@@ -15,9 +17,9 @@ urls = { Organization = "https://jupyter.org" }
 requires-python = ">=3.8"
 dependencies = [
   "myst-parser",
-  "pydata-sphinx-theme>=0.13.0rc4",
+  "pydata-sphinx-theme>=0.14.0",
   "sphinx-copybutton",
-  "sphinxext-opengraph"
+  "sphinxext-opengraph",
 ]
 
 license = { file = "LICENSE"}
@@ -31,11 +33,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.5",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Operating System :: OS Independent",
   "Topic :: Documentation",
   "Topic :: Software Development :: Documentation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "sphinx_theme_builder"
 [tool.sphinx-theme-builder]
 # ref, pydata-sphinx-theme's node version: https://github.com/pydata/pydata-sphinx-theme/blob/main/pyproject.toml
 # ref, latest node LTS version: https://nodejs.org/en
-node-version = "16.3.2"
+node-version = "16.13.2"
 
 [project]
 name = "jupyterhub-sphinx-theme"

--- a/src/jupyterhub_sphinx_theme/__init__.py
+++ b/src/jupyterhub_sphinx_theme/__init__.py
@@ -2,19 +2,13 @@
 import os
 from pathlib import Path
 from sphinx.util import logging
+from pydata_sphinx_theme.utils import config_provided_by_user
 
 __version__ = "0.0.3"
 
 THEME_PATH = (Path(__file__).parent / "theme" / "jupyterhub-sphinx-theme").resolve()
 
 logger = logging.getLogger(__name__)
-
-
-def _config_provided_by_user(app, key):
-    """Check if the user has manually provided the config.
-    REMOVE when pydata v0.14 is released and import from there.
-    """
-    return any(key in ii for ii in [app.config.overrides, app.config._raw_config])
 
 
 def set_config_defaults(app):
@@ -26,17 +20,28 @@ def set_config_defaults(app):
     if not theme:
         theme = {}
 
-    # Default jupyter favicon
-    if not _config_provided_by_user(app, "html_favicon"):
+    # Default favicon
+    if not config_provided_by_user(app, "html_favicon"):
         config.html_favicon = (
             "https://github.com/jupyterhub/jupyterhub-sphinx-theme/raw/main/src/jupyterhub_sphinx_theme/theme/jupyterhub-sphinx-theme/static/favicon.ico"
         )
+
+    # Default logo
+    if not config_provided_by_user(app, "html_logo"):
+        logo = theme.get("logo", {})
+        if "image_dark" not in logo:
+            path_dark = THEME_PATH / "static" / "hub-rectangle-dark.svg"
+            logo["image_dark"] = str(path_dark.resolve())
+        if "image_light" not in logo:
+            path_light = THEME_PATH / "static" / "hub-rectangle.svg"
+            logo["image_light"] = str(path_light.resolve())
+        theme["logo"] = logo
 
     # Navigation bar
     if "navbar_align" not in theme:
         theme["navbar_align"] = "left"
 
-    icon_links = [] if "icon_links" not in theme else theme["icon_links"]
+    icon_links = theme.get("icon_links", [])
     icon_links.extend(
         [
             {
@@ -54,18 +59,6 @@ def set_config_defaults(app):
         ]
     )
     theme["icon_links"] = icon_links
-
-    # Default logo
-    logo = {} if "logo" not in theme else theme["logo"]
-    if not logo:
-        logo = {}
-    if "image_dark" not in logo:
-        path_dark = THEME_PATH / "static" / "hub-rectangle-dark.svg"
-        logo["image_dark"] = str(path_dark.resolve())
-    if "image_light" not in logo:
-        path_light = THEME_PATH / "static" / "hub-rectangle.svg"
-        logo["image_light"] = str(path_light.resolve())
-    theme["logo"] = logo
 
     # Sphinxext Opengraph add URL based on ReadTheDocs variables
     # auto-generate this so that we don't have to manually add it in each documentation.


### PR DESCRIPTION
When html_logo was set, it was ignored because our theme defaulted to configure html_theme_options related to logo that was granted a higher priority by pydata_sphinx_theme.

With this change, we end up not providing the high-priority default if the low-priority html_logo is configured.

This enables https://github.com/jupyterhub/mybinder.org-deploy/pull/2674 to work without switching away from jupyterhub-sphinx-theme to the pydata theme.
